### PR TITLE
Feat: UserApi 보일러플레이트 작성 및 booking-waiting 페이지 로직 작성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,21 @@
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from 'src/styles/globalStyles';
 import { theme } from 'src/styles/theme';
+import { RouterProvider } from 'react-router-dom';
 import Router from './components/common/Router';
+import { RecoilRoot } from 'recoil';
+import { Suspense } from 'react';
 
 export default function App() {
   return (
     <>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <Router />
+        <RecoilRoot>
+          <Suspense>
+            <RouterProvider router={Router} />
+          </Suspense>
+        </RecoilRoot>
       </ThemeProvider>
     </>
   );

--- a/src/components/common/Router.tsx
+++ b/src/components/common/Router.tsx
@@ -1,29 +1,38 @@
-import { lazy, Suspense } from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
+import { createBrowserRouter } from 'react-router-dom';
 
-const Landing = lazy(() => import('src/pages/landing'));
-const Booking = lazy(() => import('src/pages/booking'));
-const Waiting = lazy(() => import('src/pages/waiting'));
-const Cancel = lazy(() => import('src/pages/cancel'));
-const NoTaxi = lazy(() => import('src/pages/noTaxi'));
-const Finish = lazy(() => import('src/pages/finish'));
+import Landing from '@/pages/landing';
+import Booking, { Loader as bookingLoader } from '@/pages/booking';
+import Waiting from '@/pages/waiting';
+import Cancel from '@/pages/cancel';
+import Finish from '@/pages/finish';
+import NoTaxi from '@/pages/noTaxi';
 
-const Router = () => (
-  <BrowserRouter>
-    <RecoilRoot>
-      <Suspense>
-        <Routes>
-          <Route path="/" element={<Landing />} />
-          <Route path="/booking" element={<Booking />} />
-          <Route path="/waiting" element={<Waiting />} />
-          <Route path="/cancel" element={<Cancel />} />
-          <Route path="/noTaxi" element={<NoTaxi />} />
-          <Route path="/finish" element={<Finish />} />
-        </Routes>
-      </Suspense>
-    </RecoilRoot>
-  </BrowserRouter>
-);
+const Router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Landing />,
+  },
+  {
+    path: 'booking/:qrID',
+    element: <Booking />,
+    loader: bookingLoader,
+  },
+  {
+    path: 'waiting',
+    element: <Waiting />,
+  },
+  {
+    path: 'cancel',
+    element: <Cancel />,
+  },
+  {
+    path: 'notaxi',
+    element: <NoTaxi />,
+  },
+  {
+    path: 'finish',
+    element: <Finish />,
+  },
+]);
 
 export default Router;

--- a/src/pages/booking/index.tsx
+++ b/src/pages/booking/index.tsx
@@ -4,7 +4,25 @@ import * as styles from './BookingStyle';
 import Header from '@/components/common/Header';
 import Button from '@/components/common/Button';
 
+import { Params, useLoaderData } from 'react-router-dom';
+
+import UserApi from '@/utils/api/user';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { userQRIDState } from '@/utils/recoil/store';
+import { UserLocationInfo } from '@/utils/types/user';
+
+export function Loader({ params }: { params: Params }) {
+  const [userQRID, setUserQRID] = useRecoilState(userQRIDState);
+  if (params.qrID) {
+    setUserQRID(params.qrID);
+    return UserApi.getUserLocation(userQRID);
+  }
+  return null;
+}
+
 const Booking = () => {
+  const userLocationInfo = useLoaderData() as UserLocationInfo;
+  const userQRID = useRecoilValue(userQRIDState);
   const [phoneNum, setPhoneNum] = useState<number>();
 
   const Validation = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -21,7 +39,10 @@ const Booking = () => {
     return false;
   };
 
-  const handleSubmit = () => {};
+  const handleSubmit = () => {
+    const payload = { hashed_qr_id: userQRID, user_phone: phoneNum };
+    return payload;
+  };
 
   return (
     <styles.BookingWrapper>
@@ -31,7 +52,7 @@ const Booking = () => {
       <styles.SecondSection>
         <styles.SecondContent>
           <p>나의 현재 위치는</p>
-          <h1>한국외국어대학교 정문</h1>
+          <h1>{userLocationInfo.description}</h1>
         </styles.SecondContent>
         <styles.SecondContent>
           <p>전화번호를 입력해주세요.</p>

--- a/src/pages/booking/index.tsx
+++ b/src/pages/booking/index.tsx
@@ -1,37 +1,45 @@
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 import * as styles from './BookingStyle';
 import Header from '@/components/common/Header';
 import Button from '@/components/common/Button';
 
-import { Params, useLoaderData } from 'react-router-dom';
+import {
+  Params,
+  useLoaderData,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
 
-import UserApi from '@/utils/api/user';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { userQRIDState } from '@/utils/recoil/store';
-import { UserLocationInfo } from '@/utils/types/user';
+import { UserLocationResponse, UserQRID } from '@/utils/types/user';
+import UserApi from '@/utils/api/user';
 
-export function Loader({ params }: { params: Params }) {
-  const [userQRID, setUserQRID] = useRecoilState(userQRIDState);
-  if (params.qrID) {
-    setUserQRID(params.qrID);
-    return UserApi.getUserLocation(userQRID);
-  }
-  return null;
+export async function Loader({ params }: { params: Params }) {
+  return UserApi.getUserLocation(params.qrID as string);
 }
 
 const Booking = () => {
-  const userLocationInfo = useLoaderData() as UserLocationInfo;
-  const userQRID = useRecoilValue(userQRIDState);
-  const [phoneNum, setPhoneNum] = useState<number>();
+  const userLocationInfo = useLoaderData() as UserLocationResponse;
+  const { qrID } = useParams();
+  const [userQRID, setUserQRID] = useRecoilState<UserQRID>(userQRIDState);
+  const [phoneNum, setPhoneNum] = useState<string>();
+  const navigate = useNavigate();
+
+  useLayoutEffect(() => {
+    if (qrID) {
+      setUserQRID(qrID);
+    }
+  }, []);
 
   const Validation = (e: React.ChangeEvent<HTMLInputElement>) => {
     // 유효성 검사에서 구현해야할 것들:
     // 1. 11자가 모두 입력됐는지
     // 2. 11자 이상 입력하면 막히게 해야 함
     // 3. 서버에서 제시한대로 정규화해서 보내줘야함(Post)
-    console.log(e.target.value);
-    const num = Number(e.target.value);
+    const num = e.target.value;
+    console.log(num);
     setPhoneNum(num);
     if (phoneNum && phoneNum.toString().length == 11) {
       return true;
@@ -39,9 +47,18 @@ const Booking = () => {
     return false;
   };
 
-  const handleSubmit = () => {
-    const payload = { hashed_qr_id: userQRID, user_phone: phoneNum };
-    return payload;
+  const handleSubmit = async () => {
+    try {
+      const payload = {
+        hashed_qr_id: userQRID as string,
+        user_phone: String(phoneNum),
+      };
+      const response = await UserApi.postUserInfo(payload);
+      // ws 들어갈 자리
+      if (response) navigate('/waiting');
+    } catch (error) {
+      console.error('Failed to submit user info:', error);
+    }
   };
 
   return (
@@ -64,7 +81,12 @@ const Booking = () => {
         </styles.SecondContent>
       </styles.SecondSection>
       <styles.ButtonSection>
-        <Button text="호출하기" onClick={handleSubmit} />
+        <Button
+          text="호출하기"
+          onClick={() => {
+            handleSubmit().catch(error => console.error(error));
+          }}
+        />
       </styles.ButtonSection>
     </styles.BookingWrapper>
   );

--- a/src/utils/api/axios.ts
+++ b/src/utils/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const client = axios.create({
-  baseURL: import.meta.env.BASE_URL, // vite 환경변수 접근법
+  baseURL: import.meta.env.VITE_BASE_URL as string, // vite 환경변수 접근법
 });
 
 export default client;

--- a/src/utils/api/user/index.ts
+++ b/src/utils/api/user/index.ts
@@ -1,0 +1,82 @@
+import {
+  CancelBookingPayload,
+  UserLocationResponse,
+  UserInfoPayload,
+  UserInfoResponse,
+  UserQRID,
+  DriverInfoResponse,
+  DriverInfoPayload,
+  CancelBookingResponse,
+} from '@/utils/types/user';
+import client from '../axios';
+import { AxiosResponse, isAxiosError } from 'axios';
+
+class UserApi {
+  static async getUserLocation(qrID: UserQRID) {
+    try {
+      const response = await client.get<AxiosResponse<UserLocationResponse>>(
+        `/call/main/${qrID}`,
+      );
+      return response.data;
+    } catch (error) {
+      if (isAxiosError<UserLocationResponse>(error)) {
+        console.log(error.message);
+        return null;
+      }
+      console.log('Unexpected error', error);
+      return null;
+    }
+  }
+
+  static async postUserInfo(payload: UserInfoPayload) {
+    try {
+      const response = await client.post<AxiosResponse<UserInfoResponse>>(
+        `/call/main/${payload.hashed_qr_id}`,
+        payload,
+      );
+      return response.data;
+    } catch (error) {
+      if (isAxiosError<UserInfoResponse>(error)) {
+        console.log(error.message);
+        return null;
+      }
+      console.log('Unexpected error', error);
+      return null;
+    }
+  }
+
+  static async getDriverInfo(hashed_assign_id: DriverInfoPayload) {
+    try {
+      const response = await client.get<AxiosResponse<DriverInfoResponse>>(
+        `/call/success/${hashed_assign_id}`,
+      );
+      return response.data;
+    } catch (error) {
+      if (isAxiosError<DriverInfoResponse>(error)) {
+        console.log(error.message);
+        return null;
+      }
+      console.log('Unexpected error', error);
+      return null;
+    }
+  }
+
+  static async postCancelBooking(payload: CancelBookingPayload) {
+    try {
+      const response = await client.post<AxiosResponse<CancelBookingResponse>>(
+        `/call/cancel/`,
+        payload,
+      );
+      return response.data;
+    } catch (error) {
+      if (isAxiosError<CancelBookingResponse>(error)) {
+        console.log(error.message);
+        return null;
+      }
+      console.log('Unexpected error', error);
+      return null;
+    }
+  }
+}
+
+export default UserApi;

--- a/src/utils/recoil/store.ts
+++ b/src/utils/recoil/store.ts
@@ -1,0 +1,39 @@
+import { atom, selector } from 'recoil';
+import {
+  UserLocationResponse as UserLocationInfo,
+  UserQRID,
+  UserStatus,
+} from '../types/user';
+import UserApi from '../api/user';
+
+export const userQRIDState = atom<UserQRID>({
+  key: 'userQRIDState',
+  default: null,
+});
+
+export const userLocationInfoState = selector<UserLocationInfo | null>({
+  key: 'userLocationInfoState',
+  get: async ({ get }) => {
+    const info = get(userQRIDState);
+    if (info) {
+      const response = await UserApi.getUserLocation(info);
+      return response ? response.data : response;
+    }
+    return null;
+  },
+});
+
+export const userStatus = atom<UserStatus>({
+  key: 'userState',
+  default: 'booking',
+});
+
+// export const userStatusState = selector({
+//   key: 'userStatusState',
+//   get: ({ get }) => {
+//     const status = get(userStatus);
+//     // status 바뀌는 로직 = 웹소켓
+//     if (status === 'waiting') {
+//     }
+//   },
+// });

--- a/src/utils/types/user.ts
+++ b/src/utils/types/user.ts
@@ -1,0 +1,49 @@
+export type UserQRID = string | null;
+
+export interface UserLocationResponse {
+  place: string;
+  description: string;
+}
+
+export interface UserInfoPayload {
+  hashed_qr_id: string;
+  user_phone: string;
+}
+
+export interface UserInfoResponse {
+  id: number;
+  user_phone: string;
+  status: string;
+  board_at: string;
+  qr_id: number;
+  driver_id: string | null;
+  hashed_assign_id: string;
+}
+
+export type DriverInfoPayload = UserInfoResponse['hashed_assign_id'];
+
+export interface DriverInfoResponse {
+  id: number;
+  driver_id: {
+    id: number;
+    name: string;
+    taxi_num: string;
+    car_type: string;
+  };
+  estimated_time: string;
+}
+
+export type CancelBookingPayload = UserInfoResponse['hashed_assign_id'];
+
+export interface CancelBookingResponse {
+  detail: string;
+}
+
+export type UserStatus =
+  | 'booking'
+  | 'waiting'
+  | 'success'
+  | 'riding'
+  | 'finish'
+  | 'cancel'
+  | 'deleted';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import svgr from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    port: 3000,
+  },
   base: './',
   plugins: [
     react(),


### PR DESCRIPTION
# 작업 내용
### `src/utils/api/user/index.ts`에 UserApi 클래스 작성
- 관련 type 및 interface `src/utils/types/user.ts` 에 작성
- 모든 api 함수들은 try-catch 문으로 에러 핸들링 중
- 모든 api 함수들은 통신 성공 시 명시된 response 타입 또는 통신 실패 시 null 값만을 반환

### 전역적으로 관리할 Recoil atom & selector 작성
- 크게 
  - booking 라우트 접근 시 필요한 QR 정보 = userQRIDState
  - WebSocket 연결 후 Server에서 보내는 메세지에 따라 페이지 분기처리할 atom = userStatus
  두 개로 구성
- 이 중 userStatus를 관리하는 userStatusState selector는 보류함(웹소켓 작성 시 같이 개발 예정)

### React Router 최신화
- v6 api인 createBrowserRouter로 적용
- 이는 `/booking/:qrID` 라우트에 접근 시 URL Parameter(qrID) 사용 및 컴포넌트 마운트 전 데이터 확보로 undefined 값이 없도록 하기 위함임

# 참고 자료
참고 자료는 코드 변경 사항에 코멘트 달아 놓을테니 참고 바람

# 기타 사항
6일 일요일 예정 작업: 
- [ ] waiting -> success 로직 작성
- [ ] WebSocket 작성 및 booking 라우트에서 waiting 라우트로 넘어갈 때 삽입
- [ ] WebSocket 상태 핸들링할 Recoil Selector 작성