### PR TITLE
Feat: User flow에 해당하는 빈 로직들 추가

### DIFF
--- a/src/pages/booking/index.tsx
+++ b/src/pages/booking/index.tsx
@@ -12,7 +12,11 @@ import {
 } from 'react-router-dom';
 
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { userPayloadState, userQRIDState } from '@/utils/recoil/store';
+import {
+  userPayloadState,
+  userQRIDState,
+  userStatus,
+} from '@/utils/recoil/store';
 import { UserLocationResponse, UserQRID } from '@/utils/types/user';
 import UserApi from '@/utils/api/user';
 import AssignUser from '@/utils/hooks/AssignUser';
@@ -26,6 +30,7 @@ const Booking = () => {
   const { qrID } = useParams();
   const [userQRID, setUserQRID] = useRecoilState<UserQRID>(userQRIDState);
   const [phoneNum, setPhoneNum] = useState<string>();
+  const setUserStatus = useSetRecoilState(userStatus);
   const setUserPayload = useSetRecoilState(userPayloadState);
   const navigate = useNavigate();
 
@@ -56,7 +61,7 @@ const Booking = () => {
     };
     setUserPayload(payload);
 
-    AssignUser({ payload, navigate }).catch((error: Error) => {
+    AssignUser({ payload, navigate, setUserStatus }).catch((error: Error) => {
       console.error('Failed to submit user info:', error);
     });
   };

--- a/src/pages/booking/index.tsx
+++ b/src/pages/booking/index.tsx
@@ -11,7 +11,7 @@ import {
   useParams,
 } from 'react-router-dom';
 
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { userQRIDState, userStatus } from '@/utils/recoil/store';
 import { UserLocationResponse, UserQRID, UserStatus } from '@/utils/types/user';
 import UserApi from '@/utils/api/user';
@@ -26,7 +26,7 @@ const Booking = () => {
   const { qrID } = useParams();
   const [userQRID, setUserQRID] = useRecoilState<UserQRID>(userQRIDState);
   const [phoneNum, setPhoneNum] = useState<string>();
-  const setUserStatus = useSetRecoilState(userStatus);
+  const [UserStatus, setUserStatus] = useRecoilState(userStatus);
   const navigate = useNavigate();
 
   useLayoutEffect(() => {
@@ -64,8 +64,8 @@ const Booking = () => {
           id,
           status: status as UserStatus['status'],
         };
-        console.log(data);
         setUserStatus(data);
+        console.log(UserStatus);
         initWebSocket(data.id, navigate);
         navigate('/waiting');
       }

--- a/src/pages/cancel/CancelStyle.ts
+++ b/src/pages/cancel/CancelStyle.ts
@@ -51,7 +51,7 @@ export const IconDescription = styled.p`
   color: ${({ theme }) => theme.colors.QT_Color_Gray_Black};
   text-align: center;
   margin-top: 13.5rem;
-  line-height: 5.3rem;
+  font-size: 3.5rem;
   letter-spacing: -0.03em;
 `; //margin-top으로 lottie 아이콘이랑 안겹쳐지게 함(임시)
 
@@ -59,5 +59,6 @@ export const CallBtnDescription = styled.p`
   ${({ theme }) => theme.fonts.QT_Body1_Pretendard_Medium_16}
   color: ${({ theme }) => theme.colors.QT_Color_Gray_3};
   text-align: center;
-  line-height: 2rem;
+  font-size: 2.4rem;
+  margin-bottom: 1.6rem;
 `;

--- a/src/pages/cancel/CancelStyle.ts
+++ b/src/pages/cancel/CancelStyle.ts
@@ -59,6 +59,5 @@ export const CallBtnDescription = styled.p`
   ${({ theme }) => theme.fonts.QT_Body1_Pretendard_Medium_16}
   color: ${({ theme }) => theme.colors.QT_Color_Gray_3};
   text-align: center;
-  font-size: 2.4rem;
   margin-bottom: 1.6rem;
 `;

--- a/src/pages/cancel/index.tsx
+++ b/src/pages/cancel/index.tsx
@@ -3,8 +3,24 @@ import Button from '@/components/common/Button';
 import Header from '@/components/common/Header';
 import Lottie from 'lottie-react';
 import { IcCancelled } from '@/assets/lottie';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { userPayloadState, userStatus } from '@/utils/recoil/store';
+import AssignUser from '@/utils/hooks/AssignUser';
+import { useNavigate } from 'react-router-dom';
 
 const Cancel = () => {
+  const [UserStatus, setUserStatus] = useRecoilState(userStatus);
+  const payload = useRecoilValue(userPayloadState);
+  const navigate = useNavigate();
+
+  const handleReassign = () => {
+    setUserStatus({ ...UserStatus, status: 'booking' });
+
+    AssignUser({ payload, navigate }).catch((error: Error) =>
+      console.error('Failed to submit user info:', error),
+    );
+  };
+
   return (
     <styles.FinishWrapper>
       <styles.FirstSection>
@@ -16,10 +32,16 @@ const Cancel = () => {
       </styles.FirstSection>
       <styles.FirstSection>
         <styles.CallBtnDescription>
-          <p>다시 호출하시려면</p>
-          <p>아래 버튼을 눌러주세요</p>
+          다시 호출하시려면
+          <br />
+          아래 버튼을 눌러주세요
         </styles.CallBtnDescription>
-        <Button fontSize="x-large" padding="1.6rem" text="택시 다시 호출하기" />
+        <Button
+          fontSize="x-large"
+          padding="1.6rem"
+          text="택시 다시 호출하기"
+          onClick={handleReassign}
+        />
       </styles.FirstSection>
     </styles.FinishWrapper>
   );

--- a/src/pages/cancel/index.tsx
+++ b/src/pages/cancel/index.tsx
@@ -16,7 +16,7 @@ const Cancel = () => {
   const handleReassign = () => {
     setUserStatus({ ...UserStatus, status: 'booking' });
 
-    AssignUser({ payload, navigate }).catch((error: Error) =>
+    AssignUser({ payload, navigate, setUserStatus }).catch((error: Error) =>
       console.error('Failed to submit user info:', error),
     );
   };

--- a/src/pages/cancel/index.tsx
+++ b/src/pages/cancel/index.tsx
@@ -10,21 +10,16 @@ const Cancel = () => {
       <styles.FirstSection>
         <Header />
         <styles.LottieSection>
-          <Lottie animationData={IcCancelled} />
+          <Lottie animationData={IcCancelled} loop={false} />
         </styles.LottieSection>
-        <styles.IconDescription>
-          호출이
-          <br />
-          취소되었어요
-        </styles.IconDescription>
+        <styles.IconDescription>호출이 취소되었어요</styles.IconDescription>
       </styles.FirstSection>
       <styles.FirstSection>
         <styles.CallBtnDescription>
-          다시 호출 하시려면
-          <br />
-          아래 버튼을 눌러주세요
+          <p>다시 호출하시려면</p>
+          <p>아래 버튼을 눌러주세요</p>
         </styles.CallBtnDescription>
-        <Button fontSize="x-large" text="택시 다시 호출하기" />
+        <Button fontSize="x-large" padding="1.6rem" text="택시 다시 호출하기" />
       </styles.FirstSection>
     </styles.FinishWrapper>
   );

--- a/src/pages/failed/index.tsx
+++ b/src/pages/failed/index.tsx
@@ -4,7 +4,23 @@ import Header from '@/components/common/Header';
 import Lottie from 'lottie-react';
 import { IcSadFace } from '@/assets/lottie';
 
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { userPayloadState, userStatus } from '@/utils/recoil/store';
+import { useNavigate } from 'react-router-dom';
+import AssignUser from '@/utils/hooks/AssignUser';
+
 const Failed = () => {
+  const [UserStatus, setUserStatus] = useRecoilState(userStatus);
+  const payload = useRecoilValue(userPayloadState);
+  const navigate = useNavigate();
+
+  const handleReassign = () => {
+    setUserStatus({ ...UserStatus, status: 'booking' });
+
+    AssignUser({ payload, navigate, setUserStatus }).catch((error: Error) =>
+      console.error('Failed to submit user info:', error),
+    );
+  };
   return (
     <styles.FinishWrapper>
       <styles.FirstSection>
@@ -24,7 +40,11 @@ const Failed = () => {
           <br />
           아래 버튼을 눌러주세요
         </styles.CallBtnDescription>
-        <Button fontSize="x-large" text="택시 다시 호출하기" />
+        <Button
+          fontSize="x-large"
+          text="택시 다시 호출하기"
+          onClick={handleReassign}
+        />
       </styles.FirstSection>
     </styles.FinishWrapper>
   );

--- a/src/pages/finish/index.tsx
+++ b/src/pages/finish/index.tsx
@@ -4,7 +4,21 @@ import Header from '@/components/common/Header';
 import Lottie from 'lottie-react';
 import { IcHighFive } from '@/assets/lottie';
 
+import { userPayloadState, userQRIDState } from '@/utils/recoil/store';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+
 const Finish = () => {
+  const setUserQRIDState = useSetRecoilState(userQRIDState);
+  const [userPayload, setUserPayload] = useRecoilState(userPayloadState);
+  const navigate = useNavigate();
+
+  const handleNewAssign = () => {
+    setUserQRIDState(null);
+    setUserPayload({ ...userPayload, hashed_qr_id: '' });
+    navigate('/');
+  };
+
   return (
     <styles.FinishWrapper>
       <styles.FirstSection>
@@ -24,7 +38,11 @@ const Finish = () => {
           <br />
           아래 버튼을 눌러주세요
         </styles.CallBtnDescription>
-        <Button fontSize="x-large" text="다른 택시 호출하기" />
+        <Button
+          fontSize="x-large"
+          text="다른 택시 호출하기"
+          onClick={handleNewAssign}
+        />
       </styles.FirstSection>
     </styles.FinishWrapper>
   );

--- a/src/pages/success/index.tsx
+++ b/src/pages/success/index.tsx
@@ -5,19 +5,26 @@ import { IcSuccess, IcDriver } from '@/assets/lottie';
 import { theme } from '@/styles/theme';
 import { useState } from 'react';
 import Modal from '@/components/common/Modal';
+import UserApi from '@/utils/api/user';
+import { useRecoilValue } from 'recoil';
+import { userStatus } from '@/utils/recoil/store';
+import { useNavigate } from 'react-router-dom';
 
 const Success = () => {
-  //호출 취소
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const { id: assign_id } = useRecoilValue(userStatus);
+  const navigate = useNavigate();
 
-  const openModal = () => {
-    setIsModalOpen(true);
+  const toggleModal = (isModalOpen: boolean) => {
+    setIsModalOpen(!isModalOpen);
   };
 
-  const closeModal = () => {
-    setIsModalOpen(false);
-  };
   const cancelModal = () => {
+    console.log(assign_id);
+    UserApi.postCancelBooking({ assign_id }).catch((error: Error) =>
+      console.error('Failed to cancel booking: ', error),
+    );
+    navigate('/cancel');
     setIsModalOpen(false);
   };
   //전화 연결
@@ -44,11 +51,11 @@ const Success = () => {
               color={theme.colors.QT_Color_Gray_3}
               text="호출 취소하기"
               padding="0.8rem"
-              onClick={openModal}
+              onClick={() => toggleModal(isModalOpen)}
             />
             <Modal
               isOpen={isModalOpen}
-              onClose={closeModal}
+              onClose={() => toggleModal(isModalOpen)}
               title="호출 취소"
               text1="현재 기사님이 달려오고 있어요"
               text2="정말 호출을 취소하시겠어요?"

--- a/src/pages/success/index.tsx
+++ b/src/pages/success/index.tsx
@@ -5,18 +5,26 @@ import { IcSuccess, IcDriver } from '@/assets/lottie';
 import { theme } from '@/styles/theme';
 import { useState } from 'react';
 import Modal from '@/components/common/Modal';
+import UserApi from '@/utils/api/user';
+import { useRecoilValue } from 'recoil';
+import { userStatus } from '@/utils/recoil/store';
+import { useNavigate } from 'react-router-dom';
 
 const Success = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const { id: assign_id } = useRecoilValue(userStatus);
+  const navigate = useNavigate();
 
-  const openModal = () => {
-    setIsModalOpen(true);
+  const toggleModal = (isModalOpen: boolean) => {
+    setIsModalOpen(!isModalOpen);
   };
 
-  const closeModal = () => {
-    setIsModalOpen(false);
-  };
   const cancelModal = () => {
+    console.log(assign_id);
+    UserApi.postCancelBooking({ assign_id }).catch((error: Error) =>
+      console.error('Failed to cancel booking: ', error),
+    );
+    navigate('/cancel');
     setIsModalOpen(false);
   };
   return (
@@ -29,11 +37,11 @@ const Success = () => {
               color={theme.colors.QT_Color_Gray_3}
               text="호출 취소하기"
               padding="0.8rem"
-              onClick={openModal}
+              onClick={() => toggleModal(isModalOpen)}
             />
             <Modal
               isOpen={isModalOpen}
-              onClose={closeModal}
+              onClose={() => toggleModal(isModalOpen)}
               text="현재 기사님이 달려오고 있어요"
               onCancel={cancelModal}
             />

--- a/src/pages/waiting/index.tsx
+++ b/src/pages/waiting/index.tsx
@@ -14,7 +14,7 @@ import UserApi from '@/utils/api/user';
 
 const Waiting = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const { id: assignID } = useRecoilValue(userStatus);
+  const { id: assign_id } = useRecoilValue(userStatus);
   const navigate = useNavigate();
 
   const toggleModal = (isModalOpen: boolean) => {
@@ -22,8 +22,8 @@ const Waiting = () => {
   };
 
   const cancelModal = () => {
-    console.log(assignID);
-    UserApi.postCancelBooking(assignID).catch((error: Error) =>
+    console.log(assign_id);
+    UserApi.postCancelBooking({ assign_id }).catch((error: Error) =>
       console.error('Failed to cancel booking: ', error),
     );
     navigate('/cancel');

--- a/src/pages/waiting/index.tsx
+++ b/src/pages/waiting/index.tsx
@@ -1,9 +1,35 @@
 import * as styles from './WaitingStyle';
+
 import Lottie from 'lottie-react';
 import { IcTaxi } from '@/assets/lottie';
+
 import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { userStatus } from '@/utils/recoil/store';
+import { useNavigate } from 'react-router-dom';
+import UserApi from '@/utils/api/user';
 
 const Waiting = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const { id: assignID } = useRecoilValue(userStatus);
+  const navigate = useNavigate();
+
+  const toggleModal = (isModalOpen: boolean) => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  const cancelModal = () => {
+    console.log(assignID);
+    UserApi.postCancelBooking(assignID).catch((error: Error) =>
+      console.error('Failed to cancel booking: ', error),
+    );
+    navigate('/cancel');
+    setIsModalOpen(false);
+  };
+
   return (
     <styles.WaitingWrapper>
       <styles.TextSection>
@@ -13,7 +39,17 @@ const Waiting = () => {
         <Lottie animationData={IcTaxi} />
       </styles.LottieSection>
       <styles.ButtonSection>
-        <Button text="취소하기" />
+        <Button
+          text="취소하기"
+          padding="0.8rem"
+          onClick={() => toggleModal(isModalOpen)}
+        />
+        <Modal
+          isOpen={isModalOpen}
+          onClose={() => toggleModal(isModalOpen)}
+          text="현재 배차를 요청 중이에요"
+          onCancel={cancelModal}
+        />
       </styles.ButtonSection>
     </styles.WaitingWrapper>
   );

--- a/src/pages/waiting/index.tsx
+++ b/src/pages/waiting/index.tsx
@@ -1,9 +1,35 @@
 import * as styles from './WaitingStyle';
+
 import Lottie from 'lottie-react';
 import { IcTaxi } from '@/assets/lottie';
+
 import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { userStatus } from '@/utils/recoil/store';
+import { useNavigate } from 'react-router-dom';
+import UserApi from '@/utils/api/user';
 
 const Waiting = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const { id: assign_id } = useRecoilValue(userStatus);
+  const navigate = useNavigate();
+
+  const toggleModal = (isModalOpen: boolean) => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  const cancelModal = () => {
+    console.log(assign_id);
+    UserApi.postCancelBooking({ assign_id }).catch((error: Error) =>
+      console.error('Failed to cancel booking: ', error),
+    );
+    navigate('/cancel');
+    setIsModalOpen(false);
+  };
+
   return (
     <styles.WaitingWrapper>
       <styles.TextSection>
@@ -13,7 +39,20 @@ const Waiting = () => {
         <Lottie animationData={IcTaxi} />
       </styles.LottieSection>
       <styles.ButtonSection>
-        <Button text="취소하기" />
+        <Button
+          text="취소하기"
+          padding="0.8rem"
+          onClick={() => toggleModal(isModalOpen)}
+        />
+        <Modal
+          isOpen={isModalOpen}
+          onClose={() => toggleModal(isModalOpen)}
+          title="호출 취소"
+          text1="현재 배차를 요청 중이에요"
+          text2="정말 호출을 취소하시겠어요?"
+          action="호출 취소"
+          onAction={cancelModal}
+        />
       </styles.ButtonSection>
     </styles.WaitingWrapper>
   );

--- a/src/utils/api/axios.ts
+++ b/src/utils/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const client = axios.create({
-  baseURL: `http://${import.meta.env.VITE_BASE_URL}`, // vite 환경변수 접근법
+  baseURL: `https://${import.meta.env.VITE_BASE_URL}`, // vite 환경변수 접근법
 });
 
 export default client;

--- a/src/utils/api/webSocket.ts
+++ b/src/utils/api/webSocket.ts
@@ -21,6 +21,12 @@ export const initWebSocket = (
   if (!socket) {
     console.log(ws_url);
     socket = new WebSocket(ws_url);
+  } else {
+    if (socket.url !== ws_url) {
+      console.log('기존 소켓과의 연결을 끊고 새로운 소켓을 연결합니다.');
+      closeWebSocket();
+      socket = new WebSocket(ws_url);
+    }
   }
   socket.onopen = () => {
     console.log('websocket connected');

--- a/src/utils/hooks/AssignUser.ts
+++ b/src/utils/hooks/AssignUser.ts
@@ -1,0 +1,30 @@
+import UserApi from '../api/user';
+import { initWebSocket } from '../api/webSocket';
+import { UserInfoPayload, UserStatus } from '../types/user';
+
+import { useSetRecoilState } from 'recoil';
+import { userStatus } from '../recoil/store';
+
+interface AssignUserProps {
+  payload: UserInfoPayload;
+  navigate: (path: string) => void;
+}
+
+const AssignUser = async ({ payload, navigate }: AssignUserProps) => {
+  const setUserStatus = useSetRecoilState(userStatus);
+  const response = await UserApi.postUserInfo(payload);
+
+  if (response) {
+    const { hashed_assign_id, id, status } = response;
+    const data: UserStatus = {
+      hashed_assign_id,
+      id,
+      status: status as UserStatus['status'],
+    };
+    setUserStatus(data);
+    console.log(data);
+    initWebSocket(data.id, navigate);
+    navigate('/waiting');
+  }
+};
+export default AssignUser;

--- a/src/utils/hooks/AssignUser.ts
+++ b/src/utils/hooks/AssignUser.ts
@@ -1,17 +1,18 @@
 import UserApi from '../api/user';
 import { initWebSocket } from '../api/webSocket';
-import { UserInfoPayload, UserStatus } from '../types/user';
-
-import { useSetRecoilState } from 'recoil';
-import { userStatus } from '../recoil/store';
+import { UserInfoPayload, UserStatus } from '@/utils/types/user';
 
 interface AssignUserProps {
   payload: UserInfoPayload;
   navigate: (path: string) => void;
+  setUserStatus: (arg: UserStatus) => void;
 }
 
-const AssignUser = async ({ payload, navigate }: AssignUserProps) => {
-  const setUserStatus = useSetRecoilState(userStatus);
+const AssignUser = async ({
+  payload,
+  navigate,
+  setUserStatus,
+}: AssignUserProps) => {
   const response = await UserApi.postUserInfo(payload);
 
   if (response) {

--- a/src/utils/recoil/store.ts
+++ b/src/utils/recoil/store.ts
@@ -1,5 +1,6 @@
 import { atom, selector } from 'recoil';
 import {
+  UserInfoPayload,
   UserLocationResponse as UserLocationInfo,
   UserQRID,
   UserStatus,
@@ -9,6 +10,14 @@ import UserApi from '../api/user';
 export const userQRIDState = atom<UserQRID>({
   key: 'userQRIDState',
   default: null,
+});
+
+export const userPayloadState = atom<UserInfoPayload>({
+  key: 'userPayloadState',
+  default: {
+    hashed_qr_id: '',
+    user_phone: '',
+  },
 });
 
 export const userLocationInfoState = selector<UserLocationInfo | null>({

--- a/src/utils/types/user.ts
+++ b/src/utils/types/user.ts
@@ -35,7 +35,9 @@ export interface DriverInfoResponse {
   estimated_time: string;
 }
 
-export type CancelBookingPayload = UserInfoResponse['id'];
+export interface CancelBookingPayload {
+  assign_id: UserInfoResponse['id'];
+}
 
 export interface CancelBookingResponse {
   detail: string;

--- a/src/utils/types/user.ts
+++ b/src/utils/types/user.ts
@@ -35,7 +35,7 @@ export interface DriverInfoResponse {
   estimated_time: string;
 }
 
-export type CancelBookingPayload = UserAssignID;
+export type CancelBookingPayload = UserInfoResponse['id'];
 
 export interface CancelBookingResponse {
   detail: string;


### PR DESCRIPTION
# 작업 내용 
- waiting/success 페이지 내 `취소 버튼` 로직 활성화
- failed/cancel 페이지 내 `다시호출 버튼` 로직 활성화
- 다시호출 로직에 사용되는 코드 재사용(AssignUser.ts)
- postCancelBooking api call 에러 수정
- Django admin으로 모든 로직 테스트 통과

# 기타 사항
- 신고하기 로직 추가 필요
- 페이지들 UI 피그마 버전으로 동기화 필요
- success 페이지 여백 추가 필요(배치가 너무 답답함)
