### PR TITLE
Chore: S3 배포 이후 자동 갱신을 위한 main.yml 무효화 명령어 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,8 @@ jobs:
     - name: Deploy to S3
       run: |
         aws s3 sync dist/ s3://${{ secrets.S3_BUCKET_NAME }} --delete
+    
+    - name: CloudFront invalidation
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+


### PR DESCRIPTION
#작업 내용
- 무효화란?
```
콘텐츠가 만료되기 전에 파일을 무효화하여 CloudFront 엣지 캐시에서 객체(파일)를 제거합니다.
```
- 그냥 cloudfront에 존재했던 캐시 파일들을 삭제해주는 거임.
- 이거 깃헙액션으로 될 때 자동으로 해주면 즉시 캐시 삭제해줘서 바로 갱신됨.
- 캐시를 없애거나 주기를 0으로 하는 방법도 있었는데 그러면 성능이 좋지 않다고해서 고안했습니다.
- 이제 진짜 자야지
