### PR TITLE
Feat: Reconnect websocket 기능 추가

### DIFF
--- a/src/utils/api/user/index.ts
+++ b/src/utils/api/user/index.ts
@@ -7,9 +7,12 @@ import {
   DriverInfoResponse,
   DriverInfoPayload,
   CancelBookingResponse,
+  CheckStatusPayload,
+  CheckStatusResponse,
+  CheckStatusFailedResponse,
 } from '@/utils/types/user';
 import client from '../axios';
-import { isAxiosError } from 'axios';
+import { AxiosError, AxiosResponse, isAxiosError } from 'axios';
 
 class UserApi {
   static async getUserLocation(qrID: UserQRID) {
@@ -75,6 +78,23 @@ class UserApi {
       }
       console.log('Unexpected error', error);
       return null;
+    }
+  }
+
+  static async postCheckStatus(payload: CheckStatusPayload) {
+    try {
+      const response: AxiosResponse<CheckStatusResponse> = await client.post(
+        `/call/status/`,
+        payload,
+      );
+      return response.data;
+    } catch (error) {
+      const axiosError = error as AxiosError<CheckStatusFailedResponse>;
+      if (axiosError.response) {
+        return axiosError.response.data;
+      } else {
+        throw new Error();
+      }
     }
   }
 }

--- a/src/utils/api/webSocket.ts
+++ b/src/utils/api/webSocket.ts
@@ -1,4 +1,5 @@
-import { UserStatus } from '../types/user';
+import { UserStatus } from '@/utils/types/user';
+import UserApi from '@/utils/api/user';
 
 let socket: WebSocket | null = null;
 
@@ -6,6 +7,64 @@ export function closeWebSocket() {
   if (socket !== null) {
     socket.close();
     socket = null;
+  }
+}
+
+async function handleVisibilityChange(
+  ws_url: string,
+  id: UserStatus['id'],
+  navigate: (path: string) => void,
+) {
+  if (document.hidden) {
+    console.log('background');
+    // 페이지가 백그라운드로 가려질 때 실행할 로직
+  } else {
+    console.log('now visible');
+    // 기존 소켓이 연결 상태였다가 화면 꺼짐으로 인해 끊어진 상태.
+    // id값이 변하지 않았고 다시 같은 url로 소켓 연결하면 됨
+    if (!socket) {
+      socket = new WebSocket(ws_url);
+      console.log(
+        `동일한 ws_url로 웹소켓이 재연결되었습니다. 연결이 끊어진 공백기간 동안 상태에 변화가 있는지 확인합니다. id=${id}, url=${ws_url}`,
+      );
+
+      const response = await UserApi.postCheckStatus({ assign_id: id });
+
+      if ('status' in response) {
+        const { status } = response;
+        if (!window.location.pathname.includes(status)) {
+          // 현재 라우트 pathname과 실제 상태가 일치하지 않으면 리다이렉션 발생
+          console.log(
+            `서버 상태와 클라이언트 상태 간 불일치가 감지되었습니다. ${status} 라우트로 이동합니다.`,
+          );
+          switch (status) {
+            case 'success':
+              navigate('/success');
+              break;
+            case 'failed':
+              navigate('/failed');
+              closeWebSocket();
+              break;
+            case 'cancel':
+              navigate('/cancel');
+              closeWebSocket();
+              break;
+            case 'riding':
+              navigate('/riding');
+              break;
+            case 'finish':
+              navigate('/finish');
+              closeWebSocket();
+              break;
+            default:
+              console.error(`Invalid message type : ${status}`);
+              break;
+          }
+        }
+      } else {
+        throw new Error(response.detail);
+      }
+    } else console.log(`소켓 연결이 살아있는 상태입니다. ${socket.url}`);
   }
 }
 
@@ -18,16 +77,25 @@ export const initWebSocket = (
     import.meta.env.VITE_BASE_URL
   }:${port_num}/ws/call/${id}/`;
 
+  // 화면 꺼짐/켜짐 상태 감지
+  document.addEventListener('visibilitychange', () => {
+    handleVisibilityChange(ws_url, id, navigate).catch(error =>
+      console.error(error),
+    );
+  });
+
   if (!socket) {
     console.log(ws_url);
     socket = new WebSocket(ws_url);
   } else {
     if (socket.url !== ws_url) {
+      // 다시호출 시 새로운 id로 새 웹소켓 연결
       console.log('기존 소켓과의 연결을 끊고 새로운 소켓을 연결합니다.');
       closeWebSocket();
       socket = new WebSocket(ws_url);
     }
   }
+
   socket.onopen = () => {
     console.log('websocket connected');
   };
@@ -81,11 +149,15 @@ export const initWebSocket = (
   socket.onclose = (event: CloseEvent) => {
     if (!event.wasClean) {
       console.log(
-        '웹소켓 서버가 죽었거나 네트워크 장애로 인해 연결이 종료되었습니다.',
+        `웹소켓 서버가 죽었거나 네트워크 장애로 인해 연결이 종료되었습니다(code=${event.code}).`,
       );
+    } else {
+      console.log(`연결이 정상적으로 종료되었습니다(code=${event.code})`);
+      document.removeEventListener('visibilitychange', () => {
+        handleVisibilityChange(ws_url, id, navigate).catch(error =>
+          console.error(error),
+        );
+      }); // 정상적으로 연결이 종료되었을 때만 화면 꺼짐/켜짐 상태 감지 이벤트리스너 제거
     }
-    console.log(
-      `연결이 정상적으로 종료되었습니다(code=${event.code} reason=${event.reason})`,
-    );
   };
 };

--- a/src/utils/types/user.ts
+++ b/src/utils/types/user.ts
@@ -54,3 +54,14 @@ export interface UserStatus {
     | 'finish'
     | 'cancel';
 }
+
+export interface CheckStatusPayload {
+  assign_id: UserInfoResponse['id'];
+}
+
+export interface CheckStatusResponse {
+  status: string;
+}
+export interface CheckStatusFailedResponse {
+  detail: string;
+}


### PR DESCRIPTION
# 작업 내용
- 모바일 환경에서 잦은 화면 잠금으로 웹소켓 연결 끊김 현상 발생
- Visibility API 사용하여 사용자가 화면을 다시 켰을 때 기존 assign id 값의 웹소켓에 재연결하는 로직 추가
- +) disconnected된 사이 status 변화 여부 check하는 POST 함수 작성
  - Success시 Response, Fail시 Response 분기해 null 값 return하지 않고 확실하게 response 뱉게 작성, 이에 따라 나머지 API call 함수들도 해당 함수 코드 스타일로 리팩토링 예정

# 참고 자료
- https://chat.openai.com/share/47682fe3-4ca1-44c6-b6af-106170af3373

# 기타 사항
- [x] 빈 껍데기 데이터 채우기
- [x] 껍데기ui 모바일 사이즈에 최적화시키기
- [x] 리다이렉션 완성시키기
- [x] validation 확인하기
- [ ] 미들웨어로 직접 접근 막을 수 있나 확인
- [ ] 신고하기 플로우 추가
- [x] 취소 페이지에서 새로고침하고 다시호출 누르면 recoil 초기화되는 문제 -> recoil-persist 설치 필요
- [x] framer-motion 지우기
- [x] 카메라 모바일 동작여부 확인하기

# 희망 완료일
월요일까지
